### PR TITLE
build: auto-publish to PyPI + setup.cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,12 @@
 *build/
 .fuse_*
 /*dist/
+version.py
 
 # Python temporary files
+*.egg-info/
 *.pyc
+*condaenv.*
 .coverage
 .coverage.*
 .eggs
@@ -12,7 +15,6 @@
 .pytest_cache/
 __pycache__/
 htmlcov/
-*.egg-info/
 
 # Virtual environments
 *venv/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build output
 *build/
 .fuse_*
+/*dist/
 
 # Python temporary files
 *.pyc

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,8 @@
+name: amplitf
+channels:
+  - defaults
+dependencies:
+  - python==3.8.*
+  - pip
+  - pip:
+      - -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = [
+    "setuptools>=36.2.1",
+    "setuptools_scm",
+    "wheel",
+]
+
+[tool.setuptools_scm]
+write_to = "amplitf/version.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-numpy
-sympy
-tensorflow>=2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,33 @@
+[metadata]
+name = amplitf
+author = Anton Poluektov
+long_description = file: README.md
+long_description_content_type = text/markdown
+project_urls =
+    Tracker = https://github.com/apoluekt/amplitf/issues
+    Changelog = https://github.com/apoluekt/amplitf/releases
+    Source = https://github.com/apoluekt/amplitf
+license = GPLv3 or later
+classifiers =
+    Intended Audience :: Developers
+    Intended Audience :: Science/Research
+    Natural Language :: English
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Topic :: Scientific/Engineering
+    Topic :: Scientific/Engineering :: Physics
+
+[options]
+python_requires = >=3.6, <3.10
+setup_requires =
+    setuptools_scm
+install_requires =
+    iminuit
+    numpy
+    sympy
+    tensorflow >= 2.0
+packages = find:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/apoluekt/AmpliTF",
     packages=setuptools.find_packages(),
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     install_requires=[
         'iminuit',
         'numpy',

--- a/setup.py
+++ b/setup.py
@@ -1,32 +1,6 @@
-"""
-A setuptools based setup module.
+from setuptools import setup
 
-See:
-https://packaging.python.org/guides/distributing-packages-using-setuptools/
-"""
-
-import setuptools
-
-
-def long_description():
-    """Parse long description from readme."""
-    with open("README.md", "r") as readme_file:
-        return readme_file.read()
-
-
-setuptools.setup(
-    name="amplitf",
-    author="Anton Poluektov",
-    version='0.0a0',
-    long_description=long_description(),
-    long_description_content_type="text/markdown",
-    url="https://github.com/apoluekt/AmpliTF",
-    packages=setuptools.find_packages(),
-    python_requires='>=3.6',
-    install_requires=[
-        'iminuit',
-        'numpy',
-        'sympy',
-        'tensorflow>=2.0',
-    ],
+setup(
+    use_scm_version=True,
+    setup_requires=["setuptools_scm"],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,10 @@
+"""
+A setuptools based setup module.
+
+See:
+https://packaging.python.org/guides/distributing-packages-using-setuptools/
+"""
+
 import setuptools
 
 
@@ -9,14 +16,17 @@ def long_description():
 
 setuptools.setup(
     name="amplitf",
-    version="0.0.2",
+    author="Anton Poluektov",
+    version='0.0a0',
     long_description=long_description(),
     long_description_content_type="text/markdown",
     url="https://github.com/apoluekt/AmpliTF",
     packages=setuptools.find_packages(),
-    license="GPLv3 or later",
-    python_requires=">=3.6",
-    install_requires=["numpy", "sympy", "tensorflow>=2.0"],
-    package_data={},
-    include_package_data=True,
+    python_requires='>=3.5',
+    install_requires=[
+        'iminuit',
+        'numpy',
+        'sympy',
+        'tensorflow>=2.0',
+    ],
 )


### PR DESCRIPTION
Hi @apoluekt, this PR should make it easier to publish the package to PyPI (https://pypi.org/project/amplitf). Just make a release on GitHub and the package is pushed there, with the same version.

Some related changes:
- Set-up now uses [`setuptools-scm`](https://pypi.org/project/setuptools-scm) to extract the package version from the latest Git tag
- Switched to `setup.cfg`, as that's more becoming the norm now
- The `environment.yml` file makes it easier to set up the project to start developing (if using Conda)