### PR TITLE
Mixing

### DIFF
--- a/amplitf/mixing.py
+++ b/amplitf/mixing.py
@@ -1,0 +1,116 @@
+# Copyright 2024 CERN for the benefit of the LHCb collaboration
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+r"""
+Formulas for building a model where meson mixing is involved.
+
+The mixing parameters for the mass eigenstates of a neutral meson (:math:`M^0`, :math:`\bar{M}^0`) are
+
+.. math::
+
+    \begin{align}
+    x &\equiv 2\frac{m_2-m_1}{\gamma_1+\gamma_2} = \frac{\Delta M}{\Gamma}\\
+    y &\equiv \frac{\gamma_2-\gamma_1}{\gamma_1+\gamma_2} = \frac{\Delta\Gamma}{2\Gamma},
+    \end{align}
+
+
+where :math:`m_i` and :math:`\gamma_i` (:math:`i=1,2`) are the eigenvalues of the phyical eigenstates :math:`M_{1,2}`.
+
+The time evolution of the physical states is given by
+
+.. math::
+    
+    |M_i(t)>= e^{-i(m_i-i\gamma_i/2)t}|M_i(t=0)>.
+
+
+... Continue explanation later
+"""
+import tensorflow as tf
+import amplitf.interface as atfi
+import amplitf.dynamics as atfd
+
+
+# Time evolution functions.
+@atfi.function
+def psip( t, y, tau ):
+    r"""Time evolution function :math:`\psi_+(t)`
+
+    Args:
+        t (float): decay time of the candidate
+        y (float): mixing parameter
+        tau (float): lifetime of the decaying particle
+
+    Returns:
+        float: the time evolution function for the sum of the two decay amplitudes
+    """
+    return atfi.exp( - ( 1.0 + y ) * t / tau)
+
+
+@atfi.function
+def psim( t, y, tau ):
+    r"""Time evolution function :math:`\psi_-(t)`
+
+    Args:
+        t (float): decay time of the candidate
+        x (float): mixing parameter
+        tau (float): lifetime of the decaying particle
+
+    Returns:
+        float: the time evolution function for the sum of the two decay amplitudes
+    """
+    return atfi.exp( - ( 1.0 - y ) * t / tau)
+
+
+@atfi.function
+def psii( t, x, tau ):
+    r"""Time evolution function :math:`\psi_i(t)`
+
+    Args:
+        t (float): decay time of the candidate
+        x (float): mixing parameter
+        tau (float): lifetime of the decaying particle
+
+    Returns:
+        float: the time evolution function for the sum of the two decay amplitudes
+    """
+    return atfi.exp( - atfi.complex( atfi.const(1.0) , x ) * tf.cast(t / tau, tf.complex128))
+
+
+# Probability density
+def mixing_density(ampl_dir, ampl_cnj, qoverp,
+                   time_evolution_pos, time_evolution_neg, time_evolution_int):
+    """Calculates the probability density of the mixing
+
+    Args:
+        ampl_dir (complex): amplitude of the direct decay
+        ampl_cnj (complex): amplitude of the charged conjugate decay
+        qoverp (complex): CP violation
+        time_evolution_pos (float): time evolution of the sum of the decays
+        time_evolution_neg (float): time evolution of the subtraction of the decays
+        time_evolution_int (complex): time evolution of the interference of the decays
+
+    Returns:
+        float: the density of probability for the event
+    """    
+    ampDir = ampl_dir
+    ampCnj = qoverp * ampl_cnj
+
+    apb2 = 0.5 * (ampDir + ampCnj)
+    amb2 = 0.5 * atfi.conjugate(ampDir - ampCnj)
+
+    dens  = atfd.density( apb2 ) * time_evolution_pos
+    dens += atfd.density( amb2 ) * time_evolution_neg
+    dens += 2.0 * tf.math.real( apb2 * amb2 * time_evolution_int )
+    return dens

--- a/amplitf/phasespace/combined_phasespace.py
+++ b/amplitf/phasespace/combined_phasespace.py
@@ -35,13 +35,12 @@ class CombinedPhaseSpace:
 
     @atfi.function
     def data1(self, x):
-        return tf.slice(x, [0, 0], [-1, self.phsp1.dimensionality()])
+        return x[..., :self.phsp1.dimensionality()]
+        #return tf.slice(x, [0, 0], [-1, self.phsp1.dimensionality()])
 
     @atfi.function
     def data2(self, x):
-        return tf.slice(
-            x, [0, self.phsp1.dimensionality()], [-1, -1]
-        )
+        return tf.slice(x,[0, self.phsp1.dimensionality()],[-1, self.phsp2.dimensionality()])
 
     @atfi.function
     def inside(self, x):

--- a/amplitf/phasespace/decaytime_phasespace.py
+++ b/amplitf/phasespace/decaytime_phasespace.py
@@ -1,0 +1,82 @@
+# Copyright 2024 CERN for the benefit of the LHCb collaboration
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import math
+import numpy as np
+import tensorflow as tf
+import amplitf.interface as atfi
+
+
+class DecayTimePhaseSpace:
+    """
+    Class for decay time phase space
+    """
+
+    def __init__(self, tau=1.0):
+        """
+        Constructor
+        """
+        self.tau = tau
+
+    @atfi.function
+    def inside(self, x):
+        """
+        Check if the point x is inside the phase space (x > 0)
+        """
+        t = self.t(x)
+        inside = tf.greater(t, 0)
+        return inside
+
+    @atfi.function
+    def filter(self, x):
+        return tf.boolean_mask(x, self.inside(x))
+
+    #@atfi.function
+    def unfiltered_sample(self, size, maximum=None):
+        """
+        Return TF graph for uniform sample of points within phase space.
+          size     : number of _initial_ points to generate. Not all of them will fall into phase space,
+                     so the number of points in the output will be <size.
+          majorant : if majorant>0, add 2nd dimension to the generated tensor which is
+                     uniform number from 0 to majorant. Useful for accept-reject toy MC.
+        """
+        u = tf.random.uniform([size], 0, 1, dtype=atfi.fptype())
+        v = [-atfi.log(1-u) * self.tau]
+        if maximum is not None:
+            v += [tf.random.uniform([size], 0.0, maximum, dtype=atfi.fptype())]
+        return tf.stack(v, axis=1)
+
+    #@atfi.function
+    def uniform_sample(self, size, maximum=None):
+        """
+        Generate uniform sample of point within phase space.
+          size     : number of _initial_ points to generate. Not all of them will fall into phase space,
+                     so the number of points in the output will be <size.
+          majorant : if majorant>0, add 3rd dimension to the generated tensor which is
+                     uniform number from 0 to majorant. Useful for accept-reject toy MC.
+        Note it does not actually generate the sample, but returns the data flow graph for generation,
+        which has to be run within TF session.
+        """
+        return self.filter(self.unfiltered_sample(size, maximum))
+
+    def dimensionality(self):
+        return 1
+
+    def bounds(self):
+        return list(self.ranges)
+    
+    @atfi.function
+    def t(self, sample):
+        return sample[..., 0]


### PR DESCRIPTION
Functions to describe time evolution of the decay depending on mixing parameters are added through a new library `mixing.py`. The same library contains a function to calculate the probability density when mixing is present.
For implementing mixing in the models, another dimension needs to be added to the phase-space. A class `DecayTimePhaseSpace` is written to deal with decay time phase space. The default generation of decay time candidates is an exponential with decay time `tau` set to 1 by default but that can be customized when defining the object.
A small modification is required to `combined_phasespace` class to retrieve correctly the data relevant to each phase space. Most likely this is a bug fix.

Added an example to TFA2/demos (https://github.com/apoluekt/TFA2/pull/10)